### PR TITLE
Address Suppression Service and Validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file, in reverse 
 ### Added
 
 - `IsPermittedSender` validator that validates an email address as a string as a permitted sender or not.
+- `NotSuppressed` validator that checks an email address is not in the list of suppressed addresses
+- `SuppressionList` service for checking email addresses against Postmark's suppression lists.
 
 ### Changed
 

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -26,6 +26,7 @@ class ConfigProvider
             'factories' => [
                 Transport\PostmarkTransport::class => Container\PostmarkTransportFactory::class,
                 PermittedSenders::class => Container\PermittedSendersFactory::class,
+                SuppressionList::class => Container\SuppressionListFactory::class,
             ],
             'aliases' => [
                 TransportInterface::class => Transport\PostmarkTransport::class,

--- a/src/Container/CacheServiceRequirement.php
+++ b/src/Container/CacheServiceRequirement.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netglue\Mail\Postmark\Container;
+
+use Psr\Cache\CacheItemPoolInterface;
+use Psr\Container\ContainerInterface;
+use RuntimeException;
+
+trait CacheServiceRequirement
+{
+    private function retrieveCache(ContainerInterface $container): CacheItemPoolInterface
+    {
+        $config = $container->get('config')['postmark'];
+        $cacheId = $config['cache_service'] ?? null;
+        if (! $cacheId || ! $container->has($cacheId)) {
+            throw new RuntimeException(
+                'A cache service must be defined in your container configuration under the key '
+                . '[postmark][cache_service] that resolves to a Psr\Cache\CacheItemPoolInterface ' .
+                'implementation of your choosing.'
+            );
+        }
+
+        return $container->get($cacheId);
+    }
+}

--- a/src/Container/PermittedSendersFactory.php
+++ b/src/Container/PermittedSendersFactory.php
@@ -7,25 +7,18 @@ namespace Netglue\Mail\Postmark\Container;
 use Netglue\Mail\Postmark\PermittedSenders;
 use Postmark\PostmarkAdminClient;
 use Psr\Container\ContainerInterface;
-use RuntimeException;
 
 class PermittedSendersFactory
 {
+    use CacheServiceRequirement;
+
     public function __invoke(ContainerInterface $container): PermittedSenders
     {
-        $config = $container->get('config')['postmark'];
-        $cacheId = $config['cache_service'] ?? null;
-        if (! $cacheId || ! $container->has($cacheId)) {
-            throw new RuntimeException(
-                'In order to use the permitted senders helper, a cache service must be defined in ' .
-                'configuration under the key [postmark][cache_service] that resolves to a Psr\Cache\CacheItemPoolInterface ' .
-                'implementation of your choosing.'
-            );
-        }
+        $cache = $this->retrieveCache($container);
 
         return new PermittedSenders(
             $container->get(PostmarkAdminClient::class),
-            $container->get($cacheId)
+            $cache
         );
     }
 }

--- a/src/Container/SuppressionListFactory.php
+++ b/src/Container/SuppressionListFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netglue\Mail\Postmark\Container;
+
+use Netglue\Mail\Postmark\SuppressionList;
+use Postmark\PostmarkClient;
+use Psr\Container\ContainerInterface;
+
+final class SuppressionListFactory
+{
+    use CacheServiceRequirement;
+
+    public function __invoke(ContainerInterface $container): SuppressionList
+    {
+        return new SuppressionList(
+            $container->get(PostmarkClient::class),
+            $this->retrieveCache($container)
+        );
+    }
+}

--- a/src/Exception/NotAnEmailAddress.php
+++ b/src/Exception/NotAnEmailAddress.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netglue\Mail\Postmark\Exception;
+
+use InvalidArgumentException;
+
+use function sprintf;
+
+final class NotAnEmailAddress extends InvalidArgumentException
+{
+    public static function withString(string $invalidValue): self
+    {
+        return new self(sprintf(
+            'The value "%s" is not a valid email address',
+            $invalidValue
+        ));
+    }
+}

--- a/src/SuppressionList.php
+++ b/src/SuppressionList.php
@@ -15,7 +15,7 @@ use function is_iterable;
 use function is_string;
 use function strtolower;
 
-final class SuppressionList
+class SuppressionList
 {
     public const SUPPRESSION_LIST_CACHE_KEY = 'PostmarkSuppressionList';
 

--- a/src/SuppressionList.php
+++ b/src/SuppressionList.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netglue\Mail\Postmark;
+
+use Laminas\Validator\EmailAddress;
+use Netglue\Mail\Postmark\Exception\NotAnEmailAddress;
+use Postmark\PostmarkClient;
+use Psr\Cache\CacheItemPoolInterface;
+use UnexpectedValueException;
+
+use function in_array;
+use function is_iterable;
+use function is_string;
+use function strtolower;
+
+final class SuppressionList
+{
+    public const SUPPRESSION_LIST_CACHE_KEY = 'PostmarkSuppressionList';
+
+    /** @var PostmarkClient */
+    private $client;
+    /** @var CacheItemPoolInterface */
+    private $cache;
+    /** @var EmailAddress */
+    private $validator;
+
+    public function __construct(PostmarkClient $client, CacheItemPoolInterface $cache)
+    {
+        $this->cache = $cache;
+        $this->client = $client;
+        $this->validator = new EmailAddress();
+    }
+
+    public function seedSuppressionListCache(): void
+    {
+        $this->saveList($this->remoteList());
+    }
+
+    public function isSuppressed(string $emailAddress): bool
+    {
+        $emailAddress = strtolower($emailAddress);
+        if (! $this->validator->isValid($emailAddress)) {
+            throw NotAnEmailAddress::withString($emailAddress);
+        }
+
+        $list = $this->getList();
+        if (in_array($emailAddress, $list, true)) {
+            return true;
+        }
+
+        if ($this->queryList($emailAddress)) {
+            $list[] = $emailAddress;
+            $this->saveList($list);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Query the API for the given email address.
+     *
+     * If the email address is found in the remote suppression list return true, otherwise return false.
+     */
+    private function queryList(string $emailAddress): bool
+    {
+        return in_array($emailAddress, $this->remoteList($emailAddress), true);
+    }
+
+    /** @return string[] */
+    private function remoteList(?string $emailQuery = null): array
+    {
+        $results = [];
+        $response = $this->client->getSuppressions(null, null, null, null, $emailQuery);
+        $responseList = $response['Suppressions'] ?? [];
+        if (! is_iterable($responseList)) {
+            throw new UnexpectedValueException('Expected the Suppression list from the API to contain an array in its "Suppressions" property');
+        }
+
+        foreach ($responseList as $suppression) {
+            $email = $suppression['EmailAddress'] ?? null;
+            if (empty($email) || ! is_string($email)) {
+                throw new UnexpectedValueException('Expected each suppression item to have a string EmailAddress attribute');
+            }
+
+            $results[] = strtolower($email);
+        }
+
+        return $results;
+    }
+
+    /** @return string[] */
+    private function getList(): array
+    {
+        $item = $this->cache->getItem(self::SUPPRESSION_LIST_CACHE_KEY);
+
+        return $item->isHit() ? $item->get() : [];
+    }
+
+    /** @param string[] $list */
+    private function saveList(array $list): void
+    {
+        $item = $this->cache->getItem(self::SUPPRESSION_LIST_CACHE_KEY);
+        $item->set($list);
+        $this->cache->save($item);
+    }
+}

--- a/src/Validator/IsPermittedSender.php
+++ b/src/Validator/IsPermittedSender.php
@@ -23,6 +23,7 @@ final class IsPermittedSender extends AbstractValidator
     protected $messageTemplates = [
         self::NOT_STRING => 'Expected a string',
         self::NOT_PERMITTED => 'The email address %value% is not listed in Postmark’s sender signatures',
+        self::NOT_VALID_EMAIL => '"%value%" is not a valid email address',
     ];
 
     public function __construct(PermittedSenders $permittedSenders)

--- a/src/Validator/NotSuppressed.php
+++ b/src/Validator/NotSuppressed.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netglue\Mail\Postmark\Validator;
+
+use Laminas\Validator\AbstractValidator;
+use Laminas\Validator\EmailAddress;
+use Netglue\Mail\Postmark\SuppressionList;
+
+use function is_string;
+
+final class NotSuppressed extends AbstractValidator
+{
+    public const NOT_STRING = 'ValueNotSting';
+    public const IS_SUPPRESSED = 'IsSuppressed';
+    public const NOT_VALID_EMAIL = 'NotValidEmailAddress';
+
+    /** @var SuppressionList */
+    private $suppressionList;
+
+    /** @var string[] */
+    protected $messageTemplates = [
+        self::NOT_STRING => 'Expected a string',
+        self::IS_SUPPRESSED => 'The email address "%value%" has been suppressed. Email messages cannot be sent to this address.',
+        self::NOT_VALID_EMAIL => '"%value%" is not a valid email address',
+    ];
+
+    public function __construct(SuppressionList $suppressionList)
+    {
+        parent::__construct();
+        $this->suppressionList = $suppressionList;
+    }
+
+    /** @inheritDoc */
+    public function isValid($value): bool
+    {
+        if (! is_string($value)) {
+            $this->error(self::NOT_STRING);
+
+            return false;
+        }
+
+        $this->setValue($value);
+
+        $emailValidator = new EmailAddress();
+        if (! $emailValidator->isValid($value)) {
+            $this->error(self::NOT_VALID_EMAIL);
+
+            return false;
+        }
+
+        if ($this->suppressionList->isSuppressed($value)) {
+            $this->error(self::IS_SUPPRESSED);
+
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/tests/Container/PermittedSendersFactoryTest.php
+++ b/tests/Container/PermittedSendersFactoryTest.php
@@ -32,7 +32,7 @@ class PermittedSendersFactoryTest extends TestCase
             ->with('config')
             ->willReturn($config);
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('In order to use the permitted senders helper, a cache service must be defined');
+        $this->expectExceptionMessage('A cache service must be defined in your container configuration');
         (new PermittedSendersFactory())($this->container);
     }
 
@@ -51,7 +51,7 @@ class PermittedSendersFactoryTest extends TestCase
             ->willReturn(false);
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('In order to use the permitted senders helper, a cache service must be defined');
+        $this->expectExceptionMessage('A cache service must be defined in your container configuration');
         (new PermittedSendersFactory())($this->container);
     }
 

--- a/tests/Container/SuppressionListFactoryTest.php
+++ b/tests/Container/SuppressionListFactoryTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netglue\MailTest\Postmark\Container;
+
+use Netglue\Mail\Postmark\Container\SuppressionListFactory;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Postmark\PostmarkClient;
+use Psr\Container\ContainerInterface;
+use RuntimeException;
+
+class SuppressionListFactoryTest extends TestCase
+{
+    /** @var MockObject|ContainerInterface */
+    private $container;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->container = $this->createMock(ContainerInterface::class);
+    }
+
+    public function testThatAnExceptionIsThrownWhenThereIsNoCacheServiceConfigured(): void
+    {
+        $config = ['postmark' => []];
+        $this->container
+            ->expects(self::atLeastOnce())
+            ->method('get')
+            ->willReturnMap([
+                ['config', $config],
+                [PostmarkClient::class, $this->createMock(PostmarkClient::class)],
+            ]);
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('A cache service must be defined in your container configuration');
+        (new SuppressionListFactory())($this->container);
+    }
+}

--- a/tests/SuppressionListTest.php
+++ b/tests/SuppressionListTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netglue\MailTest\Postmark;
+
+use Laminas\Cache\Psr\CacheItemPool\CacheItemPoolDecorator;
+use Laminas\Cache\Storage\Adapter\Memory;
+use Laminas\Cache\Storage\Plugin\Serializer;
+use Netglue\Mail\Postmark\Exception\NotAnEmailAddress;
+use Netglue\Mail\Postmark\SuppressionList;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Postmark\PostmarkClient;
+use Psr\Cache\CacheItemPoolInterface;
+use UnexpectedValueException;
+
+class SuppressionListTest extends TestCase
+{
+    /** @var CacheItemPoolInterface */
+    private $cache;
+    /** @var MockObject|PostmarkClient */
+    private $client;
+    /** @var SuppressionList */
+    private $list;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->client = $this->createMock(PostmarkClient::class);
+        $adapter = new class extends Memory {
+            public function __construct()
+            {
+                parent::__construct();
+                $this->getCapabilities()->setStaticTtl($this->capabilityMarker, true);
+            }
+        };
+        $adapter->addPlugin(new Serializer());
+        $this->cache = new CacheItemPoolDecorator($adapter);
+        $this->list = new SuppressionList($this->client, $this->cache);
+    }
+
+    public function testAnInvalidEmailAddressWillCauseAnExceptionWhenCheckingForSuppression(): void
+    {
+        $this->expectException(NotAnEmailAddress::class);
+        $this->list->isSuppressed('bad-news');
+    }
+
+    public function testThatWhenAnEmailIsPresentInTheCacheTheApiWillNotBeQueried(): void
+    {
+        $item = $this->cache->getItem(SuppressionList::SUPPRESSION_LIST_CACHE_KEY);
+        $item->set(['me@example.com']);
+        $this->cache->save($item);
+
+        $this->client->expects(self::never())->method('getSuppressions');
+
+        self::assertTrue($this->list->isSuppressed('me@example.com'));
+    }
+
+    public function testPositiveSuppression(): void
+    {
+        $this->client
+            ->expects(self::once())
+            ->method('getSuppressions')
+            ->with(null, null, null, null, 'me@example.com')
+            ->willReturn([
+                'Suppressions' => [
+                    ['EmailAddress' => 'me@example.com'],
+                ],
+            ]);
+        self::assertTrue($this->list->isSuppressed('me@example.com'));
+    }
+
+    public function testNegativeSuppression(): void
+    {
+        $this->client
+            ->expects(self::once())
+            ->method('getSuppressions')
+            ->with(null, null, null, null, 'me@example.com')
+            ->willReturn([
+                'Suppressions' => [],
+            ]);
+        self::assertFalse($this->list->isSuppressed('me@example.com'));
+    }
+
+    public function testThatSuppressedEmailsFoundInTheApiAreCached(): void
+    {
+        $expect = ['me@example.com'];
+        $item = $this->cache->getItem(SuppressionList::SUPPRESSION_LIST_CACHE_KEY);
+        self::assertNotEquals($expect, $item->get());
+
+        $this->client
+            ->expects(self::once())
+            ->method('getSuppressions')
+            ->with(null, null, null, null, 'me@example.com')
+            ->willReturn([
+                'Suppressions' => [
+                    ['EmailAddress' => 'me@example.com'],
+                ],
+            ]);
+
+        self::assertTrue($this->list->isSuppressed('me@example.com'));
+        $item = $this->cache->getItem(SuppressionList::SUPPRESSION_LIST_CACHE_KEY);
+        self::assertEquals($expect, $item->get());
+    }
+
+    public function testThatAnExceptionIsThrownWhenTheApiResponseDoesNotContainAnIterableInTheSuppressionsKey(): void
+    {
+        $this->client
+            ->expects(self::once())
+            ->method('getSuppressions')
+            ->with(null, null, null, null, 'me@example.com')
+            ->willReturn(['Suppressions' => 'foo']);
+
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('Expected the Suppression list from the API to contain an array in its "Suppressions" property');
+        $this->list->isSuppressed('me@example.com');
+    }
+
+    public function testAnExceptionIsThrownWhenASuppressionItemDoesNotContainAnEmailAddress(): void
+    {
+        $this->client
+            ->expects(self::once())
+            ->method('getSuppressions')
+            ->with(null, null, null, null, 'me@example.com')
+            ->willReturn(['Suppressions' => [['foo' => 'bar']]]);
+
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('Expected each suppression item to have a string EmailAddress attribute');
+        $this->list->isSuppressed('me@example.com');
+    }
+
+    public function testThatSeedingTheCacheBehavesAsExpected(): void
+    {
+        $this->client
+            ->expects(self::once())
+            ->method('getSuppressions')
+            ->with(null, null, null, null, null)
+            ->willReturn([
+                'Suppressions' => [
+                    ['EmailAddress' => 'me@example.com'],
+                    ['EmailAddress' => 'you@example.com'],
+                ],
+            ]);
+
+        $this->list->seedSuppressionListCache();
+
+        $expect = [
+            'me@example.com',
+            'you@example.com',
+        ];
+
+        $item = $this->cache->getItem(SuppressionList::SUPPRESSION_LIST_CACHE_KEY);
+        self::assertEquals($expect, $item->get());
+    }
+}

--- a/tests/Validator/NotSuppressedTest.php
+++ b/tests/Validator/NotSuppressedTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Netglue\MailTest\Postmark\Validator;
 
 use Netglue\Mail\Postmark\SuppressionList;
-use Netglue\Mail\Postmark\Validator\IsPermittedSender;
 use Netglue\Mail\Postmark\Validator\NotSuppressed;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;

--- a/tests/Validator/NotSuppressedTest.php
+++ b/tests/Validator/NotSuppressedTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netglue\MailTest\Postmark\Validator;
+
+use Netglue\Mail\Postmark\SuppressionList;
+use Netglue\Mail\Postmark\Validator\IsPermittedSender;
+use Netglue\Mail\Postmark\Validator\NotSuppressed;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class NotSuppressedTest extends TestCase
+{
+    /** @var SuppressionList|MockObject */
+    private $list;
+    /** @var NotSuppressed */
+    private $validator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->list = $this->createMock(SuppressionList::class);
+        $this->validator = new NotSuppressed($this->list);
+    }
+
+    public function testNonEmailIsInvalid(): void
+    {
+        self::assertFalse($this->validator->isValid('foo'));
+        self::assertArrayHasKey(NotSuppressed::NOT_VALID_EMAIL, $this->validator->getMessages());
+    }
+
+    public function testNonStringValueIsInvalid(): void
+    {
+        self::assertFalse($this->validator->isValid(['not' => 'a string']));
+        self::assertArrayHasKey(NotSuppressed::NOT_STRING, $this->validator->getMessages());
+    }
+
+    public function testInvalidWhenEmailIsSuppressed(): void
+    {
+        $this->list
+            ->expects(self::once())
+            ->method('isSuppressed')
+            ->with('me@example.com')
+            ->willReturn(true);
+        self::assertFalse($this->validator->isValid('me@example.com'));
+        self::assertArrayHasKey(NotSuppressed::IS_SUPPRESSED, $this->validator->getMessages());
+        $error = $this->validator->getMessages()[NotSuppressed::IS_SUPPRESSED];
+        self::assertStringContainsString('me@example.com', $error);
+    }
+
+    public function testIsValidWhenEmailIsNotSuppressed(): void
+    {
+        $this->list
+            ->expects(self::once())
+            ->method('isSuppressed')
+            ->with('me@example.com')
+            ->willReturn(false);
+        self::assertTrue($this->validator->isValid('me@example.com'));
+    }
+}


### PR DESCRIPTION
Add a simple service to check an email address against the Postmark suppression list and a validator that consumes this service that can be used to reject email addresses present on the list.